### PR TITLE
Usar otro tema

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,4 +10,5 @@ author:
     - title: GitHub
       url: https://github.com/CamillePeigne
       icon: fab fa-github-square
-theme: jekyll-theme-cayman
+remote_theme: poole/hyde
+


### PR DESCRIPTION
Parece que el tema Hyde no está preparado para utilizarse de esta forma. Vamos a cambiar a [Hydeout](https://fongandrew.github.io/hydeout/), que es una copia de Hyde modificada para que pueda funcionar. Otra vez, haz merge de este pull request y veamos si se resuelve el problema.