### PR TITLE
Eliminar el título del contenido de la página

### DIFF
--- a/_posts/2019-10-10-content-strategy.md
+++ b/_posts/2019-10-10-content-strategy.md
@@ -3,8 +3,6 @@ title: Content Strategy
 date: 2019-10-10
 ---
 
-<h1> Content Strategy </h1>
-
 Este documento explica qué es la estrategia de contenido, por qué es importante en la implementación y monitoreo de un proyecto, cuándo se necesita, quién está a cargo de la estrategia de contenido, por cuánto tiempo es necesaria, y las herramientas necesarias para su implementación.
 
 <h3>Así que, en primer lugar, ¿qué es la estrategia de contenido?</h3>

--- a/_posts/2019-10-24-wireframes.md
+++ b/_posts/2019-10-24-wireframes.md
@@ -1,4 +1,7 @@
-<h1>Los Wireframes</h1>
+---
+title: Los Wireframes
+date: 2019-10-24
+---
 
 **¿Qué es?**
 
@@ -111,12 +114,3 @@ Hay que pensar en las personas que necesitan los diagramas, y no en los usuarios
 - Recordar los principios de diseño
 - Listar el contenido de la página
 - Usar escenarios realistas
-
-
- 
-
-
-
-
-
-


### PR DESCRIPTION
Si te fijas en [tu sitio web](http://CamillePeigne.github.io), en los posts de tu blog aparecen los títulos dos veces. Esto es porque, en el caso del post sobre estrategia de contenidos, lo has añadido dos veces: primero como parte de la información preliminar al principio del archivo:

```yaml
---
title: Content Strategy
date: 2019-10-10
---
```
 y después formateado como título de primer nivel como parte del contenido del archivo:

```html
<h1>Content strategy</h1>
```
La información preliminar es obligatoria y necesaria, y como ya incluye el título (con `title:`), no hace falta (mejor dicho, no se debe) volver a añadir como parte del texto.

En el caso del post sobre los wireframes no has añadido la información preliminar, y como es obligatoria, el sistema la genera automáticamente. Esas primeras líneas de información preliminar deben incluirse **siempre**.

En este pull request he realizado los cambios que te comento. Revísalos y haz merge para incorporarlos a tu branch principal `master` y ver los cambios reflejados en tu blog.